### PR TITLE
Исправление warning и дополнение ошибки не загрузившимися пользователями

### DIFF
--- a/src/Model/Entity/Orders/Order.php
+++ b/src/Model/Entity/Orders/Order.php
@@ -321,7 +321,7 @@ class Order
     public $customer;
 
     /**
-     * @var \RetailCrm\Api\Model\Entity\Customers\Customer
+     * @var \RetailCrm\Api\Model\Entity\CustomersCorporate\SerializedRelationAbstractCustomer
      *
      * @JMS\Type("RetailCrm\Api\Model\Entity\CustomersCorporate\SerializedRelationAbstractCustomer")
      * @JMS\SerializedName("contact")

--- a/src/Model/Entity/Orders/Order.php
+++ b/src/Model/Entity/Orders/Order.php
@@ -323,17 +323,17 @@ class Order
     /**
      * @var \RetailCrm\Api\Model\Entity\Customers\Customer
      *
-     * @JMS\Type("RetailCrm\Api\Model\Entity\Customers\Customer")
+     * @JMS\Type("RetailCrm\Api\Model\Entity\CustomersCorporate\SerializedRelationAbstractCustomer")
      * @JMS\SerializedName("contact")
      */
     public $contact;
 
     /**
-     * @var \RetailCrm\Api\Model\Entity\CustomersCorporate\Company
-     *
-     * @JMS\Type("RetailCrm\Api\Model\Entity\CustomersCorporate\Company")
-     * @JMS\SerializedName("company")
-     */
+    * @var \RetailCrm\Api\Model\Entity\CustomersCorporate\EntityWithExternalIdInput
+    *
+    * @jms\Type("RetailCrm\Api\Model\Entity\CustomersCorporate\EntityWithExternalIdInput")
+    * @jms\SerializedName("company")
+    */
     public $company;
 
     /**

--- a/src/Model/Response/ErrorResponse.php
+++ b/src/Model/Response/ErrorResponse.php
@@ -50,4 +50,12 @@ class ErrorResponse extends SuccessResponse
      * @JMS\SerializedName("combinedTo")
      */
     public $combinedTo;
+
+	 /**
+     * @var string[]
+     *
+     * @JMS\Type("array")
+     * @JMS\SerializedName("failedCustomers")
+     */
+    public $failedCustomers;
 }


### PR DESCRIPTION
Проблема была описана тут https://github.com/retailcrm/api-client-php/issues/229 и тут https://github.com/retailcrm/api-client-php/issues/228

Что же касательно ошибки - при обновлении из источника в CRM очень долго получать всю базу клиентов из API для понимания какой уже был загружен а какой нужно обновлять.

Вести отдельную базу уже загруженных в  CRM отказ неустойчиво. В связи с этим разработчику - интегратору проще попытаться добавить новых пользователей пакетом с обновлениями по существующим, а в случае ошибки - распарить текст (он вида Customer with externalId=([^ ]+) already exists) в массиве ошибок, взять externalId  не добавленных и обновить.

Однако при добавлении клиентов при указании адреса с externalId происходит проверка на существование адреса до существования пользователя и ошибки что пользователь существует нет, но есть ошибка что адрес существует без указания для какого пользователя 

<img width="778" height="424" alt="image" src="https://github.com/user-attachments/assets/df42578d-8c61-480d-b937-96a43f1d9bcb" />


Добавления в ErrorResponse.php  блока кода делает вывод ошибки таким

<img width="790" height="580" alt="image" src="https://github.com/user-attachments/assets/87e4d348-806d-4e8c-8c06-dfe28705e501" />

Тем не менее я надеюсь в RetailCRM исправят тот факт что существование адреса проверяется ДО существования пользователя выводя текст ошибки что адрес есть у другого пользователя, хотя он есть у того которого пытаемся добавить (даже если разработчик ведет учет добавленных в CRM пользователь в случае сбоя записи он не поймет что пользователь был уже добавлен по ошибке адреса)
